### PR TITLE
Fix admin layout link

### DIFF
--- a/frontend/src/layouts/AdminLayout.jsx
+++ b/frontend/src/layouts/AdminLayout.jsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 
 export default function AdminLayout({ children }) {
   return (
@@ -18,22 +18,22 @@ export default function AdminLayout({ children }) {
               </NavLink>
             </li>
             <li className="mb-4">
-              <Link href="/admin/products" className="hover:bg-gray-700 p-2 rounded block">
+              <Link to="/admin/products" className="hover:bg-gray-700 p-2 rounded block">
                 상품 관리
               </Link>
             </li>
             <li className="mb-4">
-              <Link href="/admin/sellers" className="hover:bg-gray-700 p-2 rounded block">
+              <Link to="/admin/sellers" className="hover:bg-gray-700 p-2 rounded block">
                 판매자 관리
               </Link>
             </li>
             <li className="mb-4">
-              <Link href="/admin/schedule" className="hover:bg-gray-700 p-2 rounded block">
+              <Link to="/admin/schedule" className="hover:bg-gray-700 p-2 rounded block">
                 예약 시트 관리
               </Link>
             </li>
             <li className="mb-4">
-              <Link href="/admin/progress" className="hover:bg-gray-700 p-2 rounded block">
+              <Link to="/admin/progress" className="hover:bg-gray-700 p-2 rounded block">
                 진행현황
               </Link>
             </li>

--- a/frontend/src/layouts/SellerLayout.jsx
+++ b/frontend/src/layouts/SellerLayout.jsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import { useState } from 'react';
 
 export default function SellerLayout({ children }) {
@@ -55,7 +55,7 @@ export default function SellerLayout({ children }) {
               {open.traffic && (
                 <ul className="ml-4 mt-2">
                   <li className="mb-2">
-                    <Link href="/seller/traffic" className="hover:bg-gray-700 p-2 rounded block">
+                    <Link to="/seller/traffic" className="hover:bg-gray-700 p-2 rounded block">
                       트래픽
                     </Link>
                   </li>
@@ -73,7 +73,7 @@ export default function SellerLayout({ children }) {
               {open.kita && (
                 <ul className="ml-4 mt-2">
                   <li className="mb-2">
-                    <Link href="/seller/keyword" className="hover:bg-gray-700 p-2 rounded block">
+                    <Link to="/seller/keyword" className="hover:bg-gray-700 p-2 rounded block">
                       키워드분석
                     </Link>
                   </li>


### PR DESCRIPTION
## Summary
- import `Link` in admin/seller layouts
- use `to` attribute for React Router links

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715ca23a788323bb20d54d4c77fe6a