### PR TITLE
Use SellerLayout directly in seller pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,6 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 
 // --- 레이아웃 컴포넌트 ---
 import AdminLayout from './layouts/AdminLayout';
-import SellerLayout from './layouts/SellerLayout';
 
 // --- 인증 및 공용 페이지 ---
 import PrivateRoute from './pages/PrivateRoute'; // HOC 대신 사용하는 인증 보호 라우트
@@ -76,14 +75,14 @@ function App() {
         </Route>
 
         {/* --- 판매자 페이지 그룹 --- */}
-        <Route path="/seller" element={<SellerLayout />}>
-          <Route index element={<Navigate to="/seller/dashboard" replace />} /> 
+        <Route path="/seller">
+          <Route index element={<Navigate to="/seller/dashboard" replace />} />
           <Route path="dashboard" element={<SellerDashboardPage />} />
           <Route path="reservation" element={<SellerReservationPage />} />
           <Route path="progress" element={<SellerProgressPage />} />
           <Route path="traffic" element={<SellerTrafficPage />} />
           <Route path="keyword" element={<SellerKeywordPage />} />
-          
+
           <Route path="*" element={<InvalidAccessPage />} />
         </Route>
       </Route>

--- a/frontend/src/layouts/SellerLayout.jsx
+++ b/frontend/src/layouts/SellerLayout.jsx
@@ -1,7 +1,7 @@
 import { NavLink, Link, Outlet } from 'react-router-dom';
 import { useState } from 'react';
 
-export default function SellerLayout() {
+export default function SellerLayout({ children }) {
   const [open, setOpen] = useState({ experience: false, traffic: false, kita: false });
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -91,7 +91,7 @@ export default function SellerLayout() {
           ☰
         </button>
         <main className="flex-1 p-8 bg-gray-100">
-          <Outlet />
+          {children || <Outlet />}
         </main>
       </div>
     </div>

--- a/frontend/src/pages/seller/SellerDashboard.jsx
+++ b/frontend/src/pages/seller/SellerDashboard.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'; // [수정] react-router-dom의 Link �
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from "@fullcalendar/interaction";
+import SellerLayout from '../../layouts/SellerLayout';
 
 const formatDate = (date) => {
     if (!date || !(date instanceof Date)) return '';
@@ -132,6 +133,7 @@ export default function SellerDashboardPage() {
     };
 
     return (
+        <SellerLayout>
         <>
             <h2 className="text-2xl font-bold mb-4">체험단 예약 현황 (잔여 수량 클릭 시 예약 가능)</h2>
             <div className="bg-white p-4 rounded-lg shadow-md">
@@ -151,5 +153,6 @@ export default function SellerDashboardPage() {
                 />
             </div>
         </>
+        </SellerLayout>
     );
 }

--- a/frontend/src/pages/seller/SellerKeyword.jsx
+++ b/frontend/src/pages/seller/SellerKeyword.jsx
@@ -1,11 +1,14 @@
 // src/pages/seller/SellerKeyword.jsx (Vite 환경에 맞게 수정된 최종본)
 
-// 이 페이지는 SellerLayout을 통해 렌더링되므로, 여기서 또 감쌀 필요가 없습니다.
+import SellerLayout from '../../layouts/SellerLayout';
+
 export default function SellerKeywordPage() {
   return (
-    <>
-      <h2 className="text-2xl font-bold mb-4">키워드 분석</h2>
-      <p>네이버 데이터랩 연동 예정입니다.</p>
-    </>
+    <SellerLayout>
+      <>
+        <h2 className="text-2xl font-bold mb-4">키워드 분석</h2>
+        <p>네이버 데이터랩 연동 예정입니다.</p>
+      </>
+    </SellerLayout>
   );
 }

--- a/frontend/src/pages/seller/SellerProgress.jsx
+++ b/frontend/src/pages/seller/SellerProgress.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { db, auth, onAuthStateChanged, collection, query, where, onSnapshot } from '../../firebaseConfig';
+import SellerLayout from '../../layouts/SellerLayout';
 
 export default function SellerProgressPage() {
   const [user, setUser] = useState(null); // 현재 사용자 정보
@@ -84,6 +85,7 @@ export default function SellerProgressPage() {
   }
 
   return (
+    <SellerLayout>
     <>
       <div className="flex items-center mb-4 space-x-2">
         <select value={year} onChange={e => setYear(Number(e.target.value))} className="border p-1 rounded">
@@ -135,5 +137,6 @@ export default function SellerProgressPage() {
         </table>
       </div>
     </>
+    </SellerLayout>
   );
 }

--- a/frontend/src/pages/seller/SellerReservation.jsx
+++ b/frontend/src/pages/seller/SellerReservation.jsx
@@ -9,6 +9,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from "@fullcalendar/interaction";
+import SellerLayout from '../../layouts/SellerLayout';
 
 const getBasePrice = (deliveryType, reviewType) => {
     if (deliveryType === '실배송') {
@@ -235,6 +236,7 @@ export default function SellerReservationPage() {
     const inputClass = "w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500";
 
     return (
+        <SellerLayout>
         <>
             <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
@@ -299,5 +301,6 @@ export default function SellerReservationPage() {
             {confirmCampaign && (<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={() => setConfirmCampaign(null)}><div className="bg-white p-6 rounded shadow" onClick={(e) => e.stopPropagation()}><p className="mb-4">예약확정하겠습니까?</p><div className="flex justify-center space-x-4"><button className="px-4 py-2 bg-blue-600 text-white rounded" onClick={handleConfirmReservation}>예</button><button className="px-4 py-2 bg-gray-300 rounded" onClick={() => setConfirmCampaign(null)}>아니오</button></div></div></div>)}
             {showDepositPopup && (<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={() => setShowDepositPopup(false)}><div className="bg-white p-6 rounded shadow" onClick={(e) => e.stopPropagation()}><p className="font-semibold text-lg mb-2">채종문(아이언마운틴컴퍼니)</p><p className="font-semibold text-lg">국민은행 834702-04-290385</p><button className="mt-4 px-4 py-2 bg-blue-600 text-white rounded" onClick={() => setShowDepositPopup(false)}>확인</button></div></div>)}
         </>
+        </SellerLayout>
     );
 }

--- a/frontend/src/pages/seller/SellerTraffic.jsx
+++ b/frontend/src/pages/seller/SellerTraffic.jsx
@@ -6,6 +6,7 @@ import { db, auth, onAuthStateChanged, collection, serverTimestamp, query, where
 import DatePicker from 'react-datepicker';
 import "react-datepicker/dist/react-datepicker.css"; // [추가] DatePicker CSS 임포트
 import { ko } from 'date-fns/locale';
+import SellerLayout from '../../layouts/SellerLayout';
 
 const initialTrafficProducts = [
   { category: '베이직 트래픽', name: '피에스타', description: '', retailPrice: 60000, discountRate: 1 - 33900 / 60000 },
@@ -188,6 +189,7 @@ export default function SellerTrafficPage() {
   if (isLoading) return <p>로딩 중...</p>;
 
   return (
+    <SellerLayout>
     <>
       <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
         <h1 className="text-3xl font-bold text-gray-800 mb-2">트래픽 요청서</h1>
@@ -381,5 +383,6 @@ export default function SellerTrafficPage() {
             </div>
         )}
     </>
+    </SellerLayout>
   );
 }


### PR DESCRIPTION
## Summary
- allow SellerLayout to accept children so it can be used as a wrapper
- remove SellerLayout wrapper from router
- wrap all seller pages with SellerLayout

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_687215a866dc832394ffb15fcd012917