### PR TITLE
Fix admin page table styles

### DIFF
--- a/frontend/src/pages/AdminLayout.css
+++ b/frontend/src/pages/AdminLayout.css
@@ -101,27 +101,30 @@ main h2 {
   cursor: pointer;
 }
 
-table {
+/* 공통 테이블 스타일은 별도 클래스에 적용하여
+   페이지별 테이블 스타일과 충돌하지 않도록 한다 */
+.admin-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 14px;
   border: 1px solid #dee2e6;
 }
 
-th, td {
+.admin-table th,
+.admin-table td {
   border-bottom: 1px solid #dee2e6;
   padding: 12px 10px;
   text-align: center;
   vertical-align: middle;
 }
 
-th {
+.admin-table th {
   background-color: #f8f9fa;
   font-weight: 600;
   color: #495057;
 }
 
-tbody tr:hover {
+.admin-table tbody tr:hover {
   background-color: #f1f3f5;
 }
 

--- a/frontend/src/pages/AdminMemberManagement.jsx
+++ b/frontend/src/pages/AdminMemberManagement.jsx
@@ -115,7 +115,7 @@ export default function AdminMemberManagementPage() {
                 <input type="text" placeholder="전화번호 검색" value={searchPhone} onChange={(e) => setSearchPhone(e.target.value)} />
             </div>
             <div className="table-container">
-                <table>
+                <table className="admin-table">
                     <thead>
                         <tr>
                             <th onClick={() => requestSort('mainAccountName')} className="sortable">본계정 이름<SortIndicator columnKey="mainAccountName" /></th>

--- a/frontend/src/pages/AdminProductManagement.jsx
+++ b/frontend/src/pages/AdminProductManagement.jsx
@@ -110,7 +110,7 @@ export default function AdminProductManagementPage() {
         <button onClick={downloadCsv}>엑셀 다운로드</button>
       </div>
       <div className="table-container">
-        <table>
+        <table className="admin-table">
           <thead>
             <tr>
               <th onClick={() => requestSort('productName')} className="sortable">상품명<SortIndicator columnKey="productName" /></th>

--- a/frontend/src/pages/AdminReviewManagement.jsx
+++ b/frontend/src/pages/AdminReviewManagement.jsx
@@ -148,7 +148,7 @@ export default function AdminReviewManagementPage() {
         <button onClick={downloadCsv}>엑셀 다운로드</button>
       </div>
       <div className="table-container">
-        <table>
+        <table className="admin-table">
           <thead>
             <tr>
               <th><input type="checkbox" checked={selected.size === processedRows.length && processedRows.length > 0} onChange={toggleSelectAll} /></th>

--- a/frontend/src/pages/AdminSettlement.jsx
+++ b/frontend/src/pages/AdminSettlement.jsx
@@ -141,7 +141,7 @@ export default function AdminSettlementPage() {
         <button onClick={downloadCsvForInfo} disabled={processedRows.length === 0}>정보 파일 다운로드</button>
       </div>
       <div className="table-container">
-        <table>
+        <table className="admin-table">
           <thead>
             <tr>
               <th><input type="checkbox" onChange={toggleSelectAll} checked={selected.size === processedRows.length && processedRows.length > 0} /></th>

--- a/frontend/src/pages/AdminSettlementComplete.jsx
+++ b/frontend/src/pages/AdminSettlementComplete.jsx
@@ -110,7 +110,7 @@ export default function AdminSettlementCompletePage() {
         <button onClick={resetFilters}>필터 초기화</button>
       </div>
       <div className="table-container">
-        <table>
+        <table className="admin-table">
           <thead>
             <tr>
               <th><input type="checkbox" onChange={toggleSelectAll} checked={selected.size === processedRows.length && processedRows.length > 0} /></th>


### PR DESCRIPTION
## Summary
- scope general table rules under `.admin-table` to avoid style clashes
- apply `admin-table` class to admin pages that relied on global styles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687282d269a483239f46e9349f864940