### PR TITLE
Clarify timestamp formatting

### DIFF
--- a/frontend/src/components/MemberDetailModal.jsx
+++ b/frontend/src/components/MemberDetailModal.jsx
@@ -5,7 +5,7 @@ import './ReviewDetailModal.css'; // 기존 모달 CSS 재사용
 
 const formatDate = (timestamp) => {
     if (!timestamp) return 'N/A';
-    return new Date(timestamp.seconds * 1000).toLocaleString();
+    return new Date(timestamp.seconds * 1000).toLocaleString('ko-KR');
 }
 
 export default function MemberDetailModal({ member, onClose }) {

--- a/frontend/src/pages/AdminReviewList.jsx
+++ b/frontend/src/pages/AdminReviewList.jsx
@@ -43,7 +43,7 @@ export default function AdminReviewList() {
               <td>{r.phoneNumber}</td>
               <td>{r.title}</td>
               <td>{r.createdAt?.seconds
-                     ? new Date(r.createdAt.seconds*1000).toLocaleString()
+                     ? new Date(r.createdAt.seconds*1000).toLocaleString('ko-KR')
                      : ''}</td>
             </tr>
           ))}

--- a/frontend/src/pages/AdminReviewManagement.jsx
+++ b/frontend/src/pages/AdminReviewManagement.jsx
@@ -83,7 +83,7 @@ export default function AdminReviewManagementPage() {
   const downloadCsv = () => {
     if (processedRows.length === 0) return alert("다운로드할 데이터가 없습니다.");
     const csvData = processedRows.map(r => ({
-      '등록일시': r.createdAt?.seconds ? new Date(r.createdAt.seconds * 1000).toLocaleString('ko-KR') : '', '상태': statusMap[r.status] || r.status, '상품명': r.productName, '결제 종류': r.reviewType,
+      '구매폼 등록일시': r.createdAt?.seconds ? new Date(r.createdAt.seconds * 1000).toLocaleString('ko-KR') : '', '상태': statusMap[r.status] || r.status, '상품명': r.productName, '결제 종류': r.reviewType,
       '본계정': r.mainAccountName, '타계정': r.name, '전화번호': r.phoneNumber, '주소': r.address, '쿠팡ID': r.participantId, '주문번호': r.orderNumber, '금액': r.rewardAmount,
       '결제유형': r.paymentType, '상품종류': r.productType, '리뷰종류': r.reviewOption, '은행': r.bank, '계좌번호': r.bankNumber, '예금주': r.accountHolderName,
       '리뷰인증': r.confirmImageUrls?.length > 0 ? 'O' : 'X', '반려사유': r.rejectionReason || ''
@@ -152,7 +152,7 @@ export default function AdminReviewManagementPage() {
           <thead>
             <tr>
               <th><input type="checkbox" checked={selected.size === processedRows.length && processedRows.length > 0} onChange={toggleSelectAll} /></th>
-              <th onClick={() => requestSort('createdAt')} className="sortable">등록일시<SortIndicator columnKey="createdAt" /></th>
+              <th onClick={() => requestSort('createdAt')} className="sortable">구매폼 등록일시<SortIndicator columnKey="createdAt" /></th>
               <th onClick={() => requestSort('status')} className="sortable">상태<SortIndicator columnKey="status" /></th>
               <th onClick={() => requestSort('productName')} className="sortable">상품명<SortIndicator columnKey="productName" /></th>
               <th onClick={() => requestSort('payType')} className="sortable">결제 종류<SortIndicator columnKey="payType" /></th>
@@ -182,7 +182,7 @@ export default function AdminReviewManagementPage() {
             {processedRows.map((r) => (
               <tr key={r.id}>
                 <td><input type="checkbox" checked={selected.has(r.id)} onChange={() => toggleSelect(r.id)} /></td>
-                <td>{r.createdAt?.seconds ? new Date(r.createdAt.seconds * 1000).toLocaleString() : ''}</td>
+                <td>{r.createdAt?.seconds ? new Date(r.createdAt.seconds * 1000).toLocaleString('ko-KR') : ''}</td>
                 <td>{statusMap[r.status] || r.status}</td>
                 <td className="product-name-cell">{r.productName || '-'}</td>
                 <td>{r.payType || '-'}</td>

--- a/frontend/src/pages/admin/SellerAdminProductManagement.jsx
+++ b/frontend/src/pages/admin/SellerAdminProductManagement.jsx
@@ -152,7 +152,7 @@ export default function AdminProductManagementPage() {
             <thead className="bg-gray-50">
               <tr>
                 <th className={thClass}><input type="checkbox" onChange={handleSelectAll} checked={selectedIds.length === filteredCampaigns.length && filteredCampaigns.length > 0} /></th>
-                <th className={thClass}>등록일시</th>
+                <th className={thClass}>상품 등록일시</th>
                 <th className={thClass}>상태</th>
                 <th className={thClass}>상품명</th>
                 <th className={thClass}>결제 종류</th>
@@ -167,7 +167,7 @@ export default function AdminProductManagementPage() {
                 {filteredCampaigns.map((c) => (
                   <tr key={c.id} className="hover:bg-gray-50">
                     <td className="px-3 py-4"><input type="checkbox" checked={selectedIds.includes(c.id)} onChange={() => handleSelectOne(c.id)} /></td>
-                    <td className="px-3 py-4 whitespace-nowrap text-sm text-gray-500">{c.createdAt?.seconds ? new Date(c.createdAt.seconds * 1000).toLocaleString() : 'N/A'}</td>
+                    <td className="px-3 py-4 whitespace-nowrap text-sm text-gray-500">{c.createdAt?.seconds ? new Date(c.createdAt.seconds * 1000).toLocaleString('ko-KR') : 'N/A'}</td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm"><span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${c.status === '리뷰완료' ? 'bg-blue-100 text-blue-800' : c.status === '예약 확정' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>{c.status}</span></td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{c.productName}</td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm">-</td>


### PR DESCRIPTION
## Summary
- ensure tables display Korean-formatted timestamps
- keep CSV and table headers distinct for product vs review dates

## Testing
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_687292597b2c8323bffaa8e5e1c77a33