### PR TITLE
Allow admin access to seller pages

### DIFF
--- a/frontend/src/pages/PrivateRoute.jsx
+++ b/frontend/src/pages/PrivateRoute.jsx
@@ -52,9 +52,7 @@ export default function PrivateRoute() {
   if (path.startsWith('/admin') && authState.role !== 'admin') {
     return <Navigate to="/admin-login" replace />;
   }
-  if (path.startsWith('/seller') && authState.role !== 'seller') {
-    // 관리자는 판매자 페이지에도 접근 가능하게 하려면 아래 조건 추가
-    // if (path.startsWith('/seller') && !['seller', 'admin'].includes(authState.role)) {
+  if (path.startsWith('/seller') && !['seller', 'admin'].includes(authState.role)) {
     return <Navigate to="/seller-login" replace />;
   }
 


### PR DESCRIPTION
## Summary
- permit `admin` role to access `/seller` routes

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `npm test --prefix backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873afc04f448323a5f2c6d7f86e2052