### PR TITLE
Add password confirmation for sign-up

### DIFF
--- a/frontend/src/components/LoginModal.jsx
+++ b/frontend/src/components/LoginModal.jsx
@@ -10,6 +10,7 @@ export default function LoginModal({ onClose, onLoginSuccess }) {
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -27,6 +28,9 @@ export default function LoginModal({ onClose, onLoginSuccess }) {
         break;
       case 'password':
         setPassword(value);
+        break;
+      case 'confirmPassword':
+        setConfirmPassword(value);
         break;
       default:
         break;
@@ -59,6 +63,11 @@ export default function LoginModal({ onClose, onLoginSuccess }) {
       // --- 회원가입 로직 ---
       try {
         if (!name.trim()) return setError('이름을 입력해주세요.');
+        if (password !== confirmPassword) {
+          setError('비밀번호가 일치하지 않습니다.');
+          setSubmitting(false);
+          return;
+        }
         // Firestore에 이미 해당 전화번호로 가입한 유저가 있는지 확인 (선택적이지만 권장)
         const userByPhoneRef = doc(db, 'users_by_phone', phone.trim());
         const docSnap = await getDoc(userByPhoneRef);
@@ -109,6 +118,9 @@ export default function LoginModal({ onClose, onLoginSuccess }) {
           )}
           <input type="tel" placeholder="전화번호 ('-' 없이 입력)" value={phone} onChange={e => setPhone(e.target.value)} required />
           <input type="password" placeholder="비밀번호 (6자리 이상)" value={password} onChange={e => setPassword(e.target.value)} required />
+          {!isLoginView && (
+            <input type="password" name="confirmPassword" placeholder="비밀번호 재입력" value={confirmPassword} onChange={handleInputChange} required />
+          )}
           
           <button type="submit" className="auth-submit-btn" disabled={submitting}>
             {submitting ? '처리 중...' : (isLoginView ? '로그인' : '회원가입')}

--- a/frontend/src/pages/ReviewerLogin.jsx
+++ b/frontend/src/pages/ReviewerLogin.jsx
@@ -13,6 +13,7 @@ export default function ReviewerLogin() {
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -36,6 +37,11 @@ export default function ReviewerLogin() {
         const snap = await getDoc(userByPhoneRef);
         if (snap.exists()) {
           setError('이미 등록된 전화번호입니다. 로그인해주세요.');
+          setSubmitting(false);
+          return;
+        }
+        if (password !== confirmPassword) {
+          setError('비밀번호가 일치하지 않습니다.');
           setSubmitting(false);
           return;
         }
@@ -103,6 +109,18 @@ export default function ReviewerLogin() {
             required
           />
         </div>
+        {!isLoginView && (
+          <div className="input-with-icon">
+            <input
+              type="password"
+              name="confirmPassword"
+              placeholder="비밀번호 재입력"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+            />
+          </div>
+        )}
         <button className="login-btn" type="submit" disabled={submitting}>
           {submitting ? '처리 중...' : isLoginView ? '로그인' : '회원가입'}
         </button>

--- a/frontend/src/pages/auth/SellerSignup.jsx
+++ b/frontend/src/pages/auth/SellerSignup.jsx
@@ -14,6 +14,7 @@ import {
 export default function SellerSignupPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [bNo, setBNo] = useState('');
@@ -27,6 +28,10 @@ export default function SellerSignupPage() {
     e.preventDefault();
     if (!email || !password || !bNo || !name || !phone || !username || !nickname) {
       alert('모든 필드를 입력해주세요.');
+      return;
+    }
+    if (password !== confirmPassword) {
+      alert('비밀번호가 일치하지 않습니다.');
       return;
     }
     setIsVerifying(true);
@@ -103,6 +108,7 @@ export default function SellerSignupPage() {
         <input value={username} onChange={e => setUsername(e.target.value)} placeholder="ID" required style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <input value={nickname} onChange={e => setNickname(e.target.value)} placeholder="닉네임" required style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="PW" required style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input type="password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} placeholder="PW 재입력" required style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <input value={referrerId} onChange={e => setReferrerId(e.target.value)} placeholder="추천인 ID (선택)" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <button type="submit" disabled={isVerifying} style={{ width:'100%', padding:'10px' }}>
           {isVerifying ? '인증 중...' : '가입하기'}


### PR DESCRIPTION
## Summary
- require password confirmation during sign up
- check that both passwords match

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687518d8f7bc83239b67d8e50c2b7a96