### PR TITLE
Add preview modal on admin review images

### DIFF
--- a/frontend/src/components/ReviewDetailModal.css
+++ b/frontend/src/components/ReviewDetailModal.css
@@ -13,6 +13,28 @@
   z-index: 1000;
 }
 
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 24px;
+  width: 90%;
+  max-width: 420px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.modal .close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  border: none;
+  background: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #888;
+}
+
 .review-detail-modal {
   background-color: white;
   padding: 24px;

--- a/frontend/src/components/ReviewDetailModal.jsx
+++ b/frontend/src/components/ReviewDetailModal.jsx
@@ -26,6 +26,10 @@ export default function ReviewDetailModal({ review, onClose }) {
   const [isEditing, setIsEditing] = useState(false);
   const [currentReview, setCurrentReview] = useState(review);
   const [editableData, setEditableData] = useState({});
+  const [imagePreview, setImagePreview] = useState(null);
+
+  const openImagePreview = (url) => setImagePreview(url);
+  const closeImagePreview = () => setImagePreview(null);
 
   useEffect(() => {
     setCurrentReview(review);
@@ -92,6 +96,7 @@ export default function ReviewDetailModal({ review, onClose }) {
   };
 
   return (
+    <>
     <div className="modal-back" onClick={onClose}>
       <div className="review-detail-modal" onClick={(e) => e.stopPropagation()}>
         <button className="close-btn" onClick={onClose}>✖</button>
@@ -202,9 +207,13 @@ export default function ReviewDetailModal({ review, onClose }) {
                 return imageUrls.map((url, index) => (
                   <div key={`${key}-${index}`} className="image-item">
                     <label>{label}</label>
-                    <a href={url} target="_blank" rel="noopener noreferrer">
-                      <img src={url} alt={`${label} ${index + 1}`} className="thumb" />
-                    </a>
+                    <img
+                      src={url}
+                      alt={`${label} ${index + 1}`}
+                      className="thumb"
+                      onClick={() => openImagePreview(url)}
+                      style={{ cursor: 'pointer' }}
+                    />
                   </div>
                 ));
               }
@@ -221,9 +230,13 @@ export default function ReviewDetailModal({ review, onClose }) {
               {currentReview.confirmImageUrls.map((url, index) => (
                 <div key={index} className="image-item">
                   <label>인증 이미지 {index + 1}</label>
-                   <a href={url} target="_blank" rel="noopener noreferrer">
-                    <img src={url} alt={`리뷰 인증 ${index + 1}`} className="thumb" />
-                  </a>
+                  <img
+                    src={url}
+                    alt={`리뷰 인증 ${index + 1}`}
+                    className="thumb"
+                    onClick={() => openImagePreview(url)}
+                    style={{ cursor: 'pointer' }}
+                  />
                 </div>
               ))}
             </div>
@@ -231,5 +244,14 @@ export default function ReviewDetailModal({ review, onClose }) {
         )}
       </div>
     </div>
+    {imagePreview && (
+      <div className="modal-back" onClick={closeImagePreview}>
+        <div className="modal" onClick={(e) => e.stopPropagation()}>
+          <button className="close" onClick={closeImagePreview}>✖</button>
+          <img src={imagePreview} alt="미리보기" style={{ width: '100%' }} />
+        </div>
+      </div>
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- show admin review images in a preview modal when clicked
- add matching modal styles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ba063a508323bcea6e8f3235bee6