### PR TITLE
Fix MyReviews product filtering

### DIFF
--- a/frontend/src/pages/MyReviews.jsx
+++ b/frontend/src/pages/MyReviews.jsx
@@ -141,7 +141,7 @@ export default function MyReviews() {
   useEffect(() => {
     const fetchProducts = async () => {
       try {
-        const q = query(collection(db, 'products'), where('progressStatus', '==', '진행중'), orderBy('createdAt', 'desc'));
+        const q = query(collection(db, 'products'), orderBy('createdAt', 'desc'));
         const snap = await getDocs(q);
         setProducts(snap.docs.map(d => ({ id: d.id, ...d.data() })));
       } catch (err) {


### PR DESCRIPTION
## Summary
- show all products on the MyReviews page so completed campaigns remain visible

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687654e186148323bd15ff6970a4a8b1