### PR TITLE
Add seller traffic menu link

### DIFF
--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -40,6 +40,7 @@ export default function AdminLayout() {
           <NavLink to="/admin/seller-list">판매자 목록</NavLink>
           <NavLink to="/admin/seller-schedule">예약 시트 관리</NavLink>
           <NavLink to="/admin/seller-progress">진행현황</NavLink>
+          <NavLink to="/admin/seller-traffic">트래픽 설정</NavLink>
         </nav>
       </aside>
       <main>


### PR DESCRIPTION
## Summary
- show Seller Traffic in admin menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879324a3c5483238659c2553b87528a