### PR TITLE
Implement traffic product saving

### DIFF
--- a/frontend/src/pages/admin/SellerAdminTraffic.jsx
+++ b/frontend/src/pages/admin/SellerAdminTraffic.jsx
@@ -1,30 +1,35 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import DatePicker from 'react-datepicker';
 import "react-datepicker/dist/react-datepicker.css";
 import { ko } from 'date-fns/locale';
+import { db, doc, getDoc, setDoc } from '../../firebaseConfig';
 
-const initialTrafficProducts = [
-  { category: '베이직 트래픽', name: '피에스타', description: '', retailPrice: 60000, discountRate: 1 - 33900 / 60000 },
-  { category: '베이직 트래픽', name: '시그니처', description: '', retailPrice: 50000, discountRate: 1 - 31900 / 50000 },
-  { category: '애드온 트래픽', name: 'CP', description: '', retailPrice: 60000, discountRate: 1 - 34900 / 60000 },
-  { category: '애드온 트래픽', name: '솔트', description: '', retailPrice: 70000, discountRate: 1 - 41900 / 70000 },
-  { category: '애드온 트래픽', name: 'BBS', description: '', retailPrice: 80000, discountRate: 1 - 34900 / 80000 },
-  { category: '애드온 트래픽', name: '팡팡', description: '', retailPrice: 60000, discountRate: 1 - 39900 / 60000 },
-];
+const DEFAULT_PRODUCT = { category: '', name: '', description: '', retailPrice: 0, discountRate: 0 };
 
 export default function SellerAdminTrafficPage() {
-  const [products, setProducts] = useState(
-    initialTrafficProducts.map(p => ({
-      ...p,
-      salePrice: Math.round(p.retailPrice * (1 - p.discountRate)),
-      quantity: 0,
-      requestDate: null,
-    }))
-  );
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetch = async () => {
+      const snap = await getDoc(doc(db, 'config', 'traffic_products'));
+      if (snap.exists()) {
+        const data = snap.data().products || [];
+        setProducts(data.map(p => ({
+          ...p,
+          salePrice: Math.round(p.retailPrice * (1 - p.discountRate)),
+          quantity: 0,
+          requestDate: null,
+        })));
+      }
+      setLoading(false);
+    };
+    fetch();
+  }, []);
 
   const handleEdit = (index, field, value) => {
     const newProducts = [...products];
-    if (field === 'retailPrice') {
+    if (field === 'retailPrice' || field === 'discountRate') {
       newProducts[index][field] = Number(value);
       newProducts[index].salePrice = Math.round(newProducts[index].retailPrice * (1 - newProducts[index].discountRate));
     } else {
@@ -54,6 +59,21 @@ export default function SellerAdminTrafficPage() {
   const thClass = "px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider bg-gray-100 border-b border-r border-gray-200";
   const tdClass = "px-4 py-3 whitespace-nowrap text-sm text-gray-800 border-b border-r border-gray-200";
   const inputClass = "w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-center";
+
+  const addRow = () => {
+    setProducts(prev => [...prev, { ...DEFAULT_PRODUCT, salePrice: 0, quantity: 0, requestDate: null }]);
+  };
+
+  const saveProducts = async () => {
+    const plain = products.map(p => {
+      const { salePrice, quantity, requestDate, ...rest } = p;
+      return rest;
+    });
+    await setDoc(doc(db, 'config', 'traffic_products'), { products: plain });
+    alert('저장되었습니다.');
+  };
+
+  if (loading) return <p>로딩 중...</p>;
 
   return (
     <>
@@ -102,6 +122,7 @@ export default function SellerAdminTrafficPage() {
                           <td className={`${tdClass} text-xs`}>
                             <div className="flex flex-col space-y-1">
                               <input type="number" value={p.retailPrice} onChange={e => handleEdit(index, 'retailPrice', e.target.value)} className={inputClass} />
+                              <input type="number" value={p.discountRate} onChange={e => handleEdit(index, 'discountRate', e.target.value)} step="0.01" className={inputClass} />
                               <span className="text-red-600">할인율: {Math.round(p.discountRate * 100)}%</span>
                               <span className="font-bold text-blue-600 text-sm">판매가: {p.salePrice.toLocaleString()}원</span>
                             </div>
@@ -125,6 +146,10 @@ export default function SellerAdminTrafficPage() {
                 <p className="text-md">견적 합계: <span className="font-semibold">{quoteTotal.toLocaleString()}</span> 원</p>
                 <p className="text-md">세금계산서 (10%): <span className="font-semibold">{totalCommission.toLocaleString()}</span> 원</p>
                 <p className="text-lg font-bold">총 결제 금액: <span className="font-bold text-blue-600">{totalAmount.toLocaleString()}</span> 원</p>
+              </div>
+              <div className="space-x-2">
+                <button onClick={addRow} className="bg-gray-200 px-4 py-2 rounded">행 추가</button>
+                <button onClick={saveProducts} className="bg-blue-600 text-white px-4 py-2 rounded">저장</button>
               </div>
           </div>
       </div>

--- a/frontend/src/pages/seller/SellerTraffic.jsx
+++ b/frontend/src/pages/seller/SellerTraffic.jsx
@@ -2,19 +2,10 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { db, auth, onAuthStateChanged, collection, serverTimestamp, query, where, onSnapshot, writeBatch, doc, increment, updateDoc } from '../../firebaseConfig';
+import { db, auth, onAuthStateChanged, collection, serverTimestamp, query, where, onSnapshot, writeBatch, doc, increment, updateDoc, getDoc } from '../../firebaseConfig';
 import DatePicker from 'react-datepicker';
 import "react-datepicker/dist/react-datepicker.css";
 import { ko } from 'date-fns/locale';
-
-const initialTrafficProducts = [
-  { category: '베이직 트래픽', name: '피에스타', description: '', retailPrice: 60000, discountRate: 1 - 33900 / 60000 },
-  { category: '베이직 트래픽', name: '시그니처', description: '', retailPrice: 50000, discountRate: 1 - 31900 / 50000 },
-  { category: '애드온 트래픽', name: 'CP', description: '', retailPrice: 60000, discountRate: 1 - 34900 / 60000 },
-  { category: '애드온 트래픽', name: '솔트', description: '', retailPrice: 70000, discountRate: 1 - 41900 / 70000 },
-  { category: '애드온 트래픽', name: 'BBS', description: '', retailPrice: 80000, discountRate: 1 - 34900 / 80000 },
-  { category: '애드온 트래픽', name: '팡팡', description: '', retailPrice: 60000, discountRate: 1 - 39900 / 60000 },
-];
 
 const formatDateWithDay = (date) => {
     if (!date || !(date instanceof Date)) return '-';
@@ -30,14 +21,7 @@ export default function SellerTrafficPage() {
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
 
-  const [products, setProducts] = useState(
-    initialTrafficProducts.map(p => ({
-      ...p,
-      salePrice: Math.round(p.retailPrice * (1 - p.discountRate)),
-      quantity: 0,
-      requestDate: null,
-    }))
-  );
+  const [products, setProducts] = useState([]);
 
   const [savedRequests, setSavedRequests] = useState([]);
   const [deposit, setDeposit] = useState(0);
@@ -45,13 +29,29 @@ export default function SellerTrafficPage() {
   const [showDepositPopup, setShowDepositPopup] = useState(false);
   const [confirmRequest, setConfirmRequest] = useState(null);
 
+  useEffect(() => {
+    const fetchProducts = async () => {
+      const snap = await getDoc(doc(db, 'config', 'traffic_products'));
+      if (snap.exists()) {
+        const data = snap.data().products || [];
+        setProducts(data.map(p => ({
+          ...p,
+          salePrice: Math.round(p.retailPrice * (1 - p.discountRate)),
+          quantity: 0,
+          requestDate: null,
+        })));
+      }
+    };
+    fetchProducts();
+  }, []);
+
   const categoryCounts = useMemo(() => {
     const counts = {};
-    initialTrafficProducts.forEach(p => {
+    products.forEach(p => {
       counts[p.category] = (counts[p.category] || 0) + 1;
     });
     return counts;
-  }, []);
+  }, [products]);
 
   useEffect(() => {
     const unsubscribeAuth = onAuthStateChanged(auth, (currentUser) => {
@@ -122,12 +122,7 @@ export default function SellerTrafficPage() {
 
   const handleClosePopupAndReset = () => {
     setShowDepositPopup(false);
-    setProducts(
-        initialTrafficProducts.map(p => ({
-          ...p, salePrice: Math.round(p.retailPrice * (1 - p.discountRate)),
-          quantity: 0, requestDate: null,
-        }))
-    );
+    setProducts(prev => prev.map(p => ({ ...p, quantity: 0, requestDate: null })));
     setUseDeposit(false);
   };
 


### PR DESCRIPTION
## Summary
- allow admin to load/save traffic products from Firestore
- let admins add new rows and edit discount rates
- fetch traffic product list on seller page
- reset seller page quantities without constants

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793529cfbc83239e2e805c70eb52cf