### PR TITLE
Fix uploading_images status transition

### DIFF
--- a/frontend/src/pages/MyReviews.jsx
+++ b/frontend/src/pages/MyReviews.jsx
@@ -283,9 +283,17 @@ export default function MyReviews() {
       }
       
       const finalUpdateData = { ...fieldsToUpdateInReview, ...imageUrlMap };
+      if (currentReview.status === 'uploading_images') {
+        finalUpdateData.status = 'submitted';
+      }
       await updateDoc(doc(db, 'reviews', currentReview.id), finalUpdateData);
 
-      const updatedReviewData = { ...currentReview, ...editableData, ...imageUrlMap };
+      const updatedReviewData = {
+        ...currentReview,
+        ...editableData,
+        ...imageUrlMap,
+        ...(currentReview.status === 'uploading_images' ? { status: 'submitted' } : {})
+      };
       const updatedRows = rows.map(row =>
         row.id === currentReview.id
           ? {


### PR DESCRIPTION
## Summary
- ensure editing a review in uploading_images status changes it to submitted

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879dc7326c883239deeae5fda2258a1