### PR TITLE
Add PWA configuration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,9 @@
     <title>Review Platform</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <!-- [추가] 토스페이먼츠 결제 위젯 SDK 스크립트 -->
     <script src="https://js.tosspayments.com/v1/payment-widget"></script>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.19",
+    "vite-plugin-pwa": "^0.18.0",
     "eslint": "^8.57.0",
     "eslint-config-google": "^0.14.0",
     "postcss": "^8.4.38",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Review Platform",
+  "short_name": "Review",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone",
+  "scope": "/",
+  "start_url": "/",
+  "icons": [
+    {
+      "src": "/pwa-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/pwa-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,12 +3,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { registerSW } from 'virtual:pwa-register';
 import App from './App';
 import './index.css'; // [추가] Tailwind CSS를 포함한 전역 스타일을 불러옵니다.
 
-// ▼▼▼ 디버깅을 위해 이 코드를 추가 ▼▼▼
-console.log("읽어온 API 키:", import.meta.env.VITE_FIREBASE_API_KEY);
-// ▲▲▲ 추가 완료 ▲▲▲
+registerSW();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,10 +2,32 @@
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path'; // [추가] Node.js의 'path' 모듈을 임포트
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      manifest: {
+        name: 'Review Platform',
+        short_name: 'Review',
+        theme_color: '#ffffff',
+        icons: [
+          {
+            src: '/pwa-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: '/pwa-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+        ],
+      },
+    }),
+  ],
   resolve: {
     alias: [
       { find: '@', replacement: path.resolve(__dirname, 'src') },


### PR DESCRIPTION
## Summary
- add `vite-plugin-pwa` to dev deps
- configure PWA plugin in `vite.config.js`
- create web app manifest
- register service worker in main.jsx
- add manifest and meta tags in index.html

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e2d9f2cac8323a385bf01525371d8