### PR TITLE
Fix review filter pagination

### DIFF
--- a/frontend/src/pages/AdminReviewManagement.jsx
+++ b/frontend/src/pages/AdminReviewManagement.jsx
@@ -112,6 +112,12 @@ export default function AdminReviewManagementPage() {
     return processedRows.slice(startIndex, startIndex + itemsPerPage);
   }, [processedRows, currentPage]);
 
+  // Reset to first page when filters change to ensure results are visible
+  useEffect(() => {
+    setCurrentPage(1);
+    setPageGroup(0);
+  }, [filters]);
+
   const totalPages = Math.ceil(processedRows.length / itemsPerPage);
   // ensure page group follows current page
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure the review table resets to the first page when filters change so filtered data always appears

## Testing
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e74c063248323ab275ae83d1b6dbc