### PR TITLE
Add settlement amount check column

### DIFF
--- a/frontend/src/pages/AdminSettlement.jsx
+++ b/frontend/src/pages/AdminSettlement.jsx
@@ -145,21 +145,26 @@ export default function AdminSettlementPage() {
   const downloadCsvForInfo = () => {
     if (processedRows.length === 0) return alert('다운로드할 정산 내역이 없습니다.');
     const toText = (v, excelText = false) => `="${(v ?? '').toString()}"`;
-    const csvData = processedRows.map(r => ({
-      '진행일자': toText(r.productInfo?.reviewDate || '-'),
-      '결제종류': toText(r.paymentType || '-'),
-      '상품종류': toText(r.productType || '-'),
-      '주문번호': toText(r.orderNumber || '-'),
-      '상품명': toText(r.productInfo?.productName || r.productName || '-'),
-      '본계정이름': toText(r.mainAccountName || '-'),
-      '타계정이름(수취인)': toText(r.subAccountName || '-'),
-      '전화번호': toText(r.phoneNumber || '-', true),
-      '주소': toText(r.address || '-'),
-      '은행': toText(r.bank || '-'),
-      '계좌번호': toText(r.bankNumber || '', true),
-      '금액': toText(r.rewardAmount || '0'),
-      '예금주': toText(r.accountHolderName || '-'),
-    }));
+    const csvData = processedRows.map(r => {
+      const amount = Number(r.rewardAmount || 0);
+      const amountCheck = r.paymentType === '현영' ? Math.floor(amount * 1.06) : amount;
+      return {
+        '진행일자': toText(r.productInfo?.reviewDate || '-'),
+        '결제종류': toText(r.paymentType || '-'),
+        '상품종류': toText(r.productType || '-'),
+        '주문번호': toText(r.orderNumber || '-'),
+        '상품명': toText(r.productInfo?.productName || r.productName || '-'),
+        '본계정이름': toText(r.mainAccountName || '-'),
+        '타계정이름(수취인)': toText(r.subAccountName || '-'),
+        '전화번호': toText(r.phoneNumber || '-', true),
+        '주소': toText(r.address || '-'),
+        '은행': toText(r.bank || '-'),
+        '계좌번호': toText(r.bankNumber || '', true),
+        '금액': toText(r.rewardAmount || '0'),
+        '예금주': toText(r.accountHolderName || '-'),
+        '금액확인': toText(amountCheck),
+      };
+    });
     const csv = Papa.unparse(csvData, { header: true });
     const blob = new Blob(["\uFEFF" + csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- extend the settlement CSV export
- append a `금액확인` column which multiplies 금액 by 1.06 and rounds down when 결제종류 is `현영`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e1480360832394e5cfa4452dc437