### PR TITLE
Fix missing guide in auto-registered products

### DIFF
--- a/frontend/src/pages/admin/SellerAdminProductManagement.jsx
+++ b/frontend/src/pages/admin/SellerAdminProductManagement.jsx
@@ -321,10 +321,15 @@ export default function AdminProductManagementPage() {
                       ? new Date(data.date.seconds * 1000)
                           .toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' })
                       : '',
+                    guide: data.reviewGuide || '',
                     progressStatus: '진행전',
                     createdAt: serverTimestamp()
                 });
                 await updateDoc(campaignRef, { productId });
+            } else {
+                await updateDoc(doc(db, 'products', productId), {
+                    guide: data.reviewGuide || ''
+                });
             }
 
             await updateDoc(campaignRef, {


### PR DESCRIPTION
## Summary
- ensure `guide` field is copied from seller campaign to product when confirming deposit

## Testing
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881749825b08323b95abe1d4e95e841