### PR TITLE
Sync payment type with VAT checkbox

### DIFF
--- a/frontend/src/pages/AdminReviewManagement.jsx
+++ b/frontend/src/pages/AdminReviewManagement.jsx
@@ -150,7 +150,7 @@ export default function AdminReviewManagementPage() {
     const toText = (v, excelText = false) => `="${(v ?? '').toString()}"`;
     const csvData = processedRows.map(r => ({
       '진행일자': toText(r.productInfo?.reviewDate || '-'),
-      '결제종류': toText(r.paymentType || '-'),
+      '결제종류': toText(r.paymentType || (r.isVatApplied ? '현영' : '자율결제')),
       '상품종류': toText(r.productType || '-'),
       '주문번호': toText(r.orderNumber || '-'),
       '상품명': toText(r.productInfo?.productName || r.productName || '-'),
@@ -271,7 +271,7 @@ export default function AdminReviewManagementPage() {
                 <TableCell>{r.mainAccountName || '-'}</TableCell>
                 <TableCell>{r.name || '-'}</TableCell>
                 <TableCell>{r.phoneNumber || '-'}</TableCell>
-                <TableCell>{r.paymentType || '-'}</TableCell>
+                <TableCell>{r.paymentType || (r.isVatApplied ? '현영' : '자율결제')}</TableCell>
                 <TableCell>{r.productType || '-'}</TableCell>
                 <TableCell>{r.reviewOption || '-'}</TableCell>
                 <TableCell><Button variant="link" size="sm" className={`link-button ${r.confirmImageUrls?.length > 0 ? 'completed' : ''}`} onClick={() => openDetailModal(r)}>{r.confirmImageUrls?.length > 0 ? 'O' : 'X'}</Button></TableCell>

--- a/frontend/src/pages/AdminSettlement.jsx
+++ b/frontend/src/pages/AdminSettlement.jsx
@@ -162,7 +162,7 @@ export default function AdminSettlementPage() {
       const amountCheck = r.paymentType === '현영' ? Math.floor(amount * 1.06) : amount;
       sheet.addRow([
         r.productInfo?.reviewDate || '-',
-        r.paymentType || '-',
+        r.paymentType || (r.isVatApplied ? '현영' : '자율결제'),
         r.productType || '-',
         r.orderNumber || '-',
         r.productInfo?.productName || r.productName || '-',
@@ -263,7 +263,7 @@ export default function AdminSettlementPage() {
                 <TableCell>{r.mainAccountName || '-'}</TableCell>
                 <TableCell>{r.subAccountName || '-'}</TableCell>
                 <TableCell>{r.phoneNumber || '-'}</TableCell>
-                <TableCell>{r.paymentType || '-'}</TableCell>
+                <TableCell>{r.paymentType || (r.isVatApplied ? '현영' : '자율결제')}</TableCell>
                 <TableCell>{r.productType || '-'}</TableCell>
                 <TableCell>{r.reviewOption || '-'}</TableCell>
                 <TableCell>{r.orderNumber || '-'}</TableCell>

--- a/frontend/src/pages/AdminSettlementComplete.jsx
+++ b/frontend/src/pages/AdminSettlementComplete.jsx
@@ -187,7 +187,7 @@ export default function AdminSettlementCompletePage() {
                 <TableCell>{r.mainAccountName || '-'}</TableCell>
                 <TableCell>{r.subAccountName || '-'}</TableCell>
                 <TableCell>{r.phoneNumber || '-'}</TableCell>
-                <TableCell>{r.paymentType || '-'}</TableCell>
+                <TableCell>{r.paymentType || (r.isVatApplied ? '현영' : '자율결제')}</TableCell>
                 <TableCell>{r.productType || '-'}</TableCell>
                 <TableCell>{r.reviewOption || '-'}</TableCell>
                 <TableCell>{r.orderNumber || '-'}</TableCell>

--- a/frontend/src/pages/admin/SellerAdminProductManagement.jsx
+++ b/frontend/src/pages/admin/SellerAdminProductManagement.jsx
@@ -414,7 +414,7 @@ export default function AdminProductManagementPage() {
         '예약 등록 일자': c.createdAt?.seconds ? new Date(c.createdAt.seconds * 1000).toLocaleDateString('ko-KR') : '',
         '진행일자': c.date?.seconds ? new Date(c.date.seconds * 1000).toLocaleDateString('ko-KR') : '',
         '구분': c.deliveryType || '',
-        '결제유형': c.paymentType || '현영',
+        '결제유형': c.paymentType || (c.isVatApplied ? '현영' : '자율결제'),
         '리뷰 종류': c.reviewType || '',
         '체험단 개수': c.quantity || '',
         '상품명': c.productName || '',
@@ -522,7 +522,7 @@ export default function AdminProductManagementPage() {
                           <td className="px-3 py-4 whitespace-nowrap text-sm">{c.deliveryType}</td>
                           <td className="px-3 py-4 whitespace-nowrap text-sm">
                             <select
-                              value={c.paymentType || '현영'}
+                              value={c.paymentType || (c.isVatApplied ? '현영' : '자율결제')}
                               onChange={e => updatePaymentType(c.id, e.target.value)}
                               className="border p-1 rounded"
                             >

--- a/frontend/src/pages/admin/SellerAdminProgress.jsx
+++ b/frontend/src/pages/admin/SellerAdminProgress.jsx
@@ -93,7 +93,7 @@ export default function AdminProgressPage() {
                   <td className="px-2 py-2">{d.toLocaleDateString()}</td>
                   <td className="px-2 py-2">{c.deliveryType}</td>
                   <td className="px-2 py-2">
-                    <select value={c.paymentType || ''} onChange={e => updatePaymentType(c.id, e.target.value)} className="border p-1 rounded w-full">
+                    <select value={c.paymentType || (c.isVatApplied ? '현영' : '자율결제')} onChange={e => updatePaymentType(c.id, e.target.value)} className="border p-1 rounded w-full">
                       <option value="">선택</option><option value="현영">현영</option><option value="자율결제">자율결제</option>
                     </select>
                   </td>

--- a/frontend/src/pages/seller/SellerProgress.jsx
+++ b/frontend/src/pages/seller/SellerProgress.jsx
@@ -162,7 +162,7 @@ export default function SellerProgressPage() {
                       <TableCell className="text-center">{idx + 1}</TableCell>
                       <TableCell className="font-mono">{d.toLocaleDateString()}</TableCell>
                       <TableCell className="text-center"><Badge variant="outline">{c.deliveryType}</Badge></TableCell>
-                      <TableCell className="text-center">{c.paymentType || '-'}</TableCell>
+                      <TableCell className="text-center">{c.paymentType || (c.isVatApplied ? '현영' : '자율결제')}</TableCell>
                       <TableCell className="text-center"><Badge>{c.reviewType}</Badge></TableCell>
                       <TableCell className="text-center">{idx + 1}</TableCell>
                       <TableCell className="font-medium">{c.productName}</TableCell>

--- a/frontend/src/pages/seller/SellerReservation.jsx
+++ b/frontend/src/pages/seller/SellerReservation.jsx
@@ -412,6 +412,7 @@ export default function SellerReservationPage() {
                 createdAt: serverTimestamp(),
                 status: '예약 대기',
                 paymentReceived: isFullDepositPayment,
+                paymentType: isVatApplied ? '현영' : '자율결제',
                 isVatApplied,
                 reviewFee,
                 productPriceWithAgencyFee,


### PR DESCRIPTION
## Summary
- set `paymentType` based on VAT choice when creating campaigns
- show default payment type from `isVatApplied` if field missing

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824c1ed4d88323918cdc0d6240710d