### PR TITLE
Hide serial number column in admin reviews

### DIFF
--- a/frontend/src/pages/AdminReviewManagement.jsx
+++ b/frontend/src/pages/AdminReviewManagement.jsx
@@ -236,7 +236,6 @@ export default function AdminReviewManagementPage() {
               <TableHead><input type="checkbox" checked={paginatedRows.length > 0 && paginatedRows.every(r => selected.has(r.id))} onChange={toggleSelectAll} /></TableHead>
               <TableHead onClick={() => requestSort('createdAt')} className="sortable">구매폼 등록일시<SortIndicator columnKey="createdAt" /></TableHead>
               <TableHead onClick={() => requestSort('status')} className="sortable">상태<SortIndicator columnKey="status" /></TableHead>
-              <TableHead>고유번호</TableHead>
               <TableHead onClick={() => requestSort('productName')} className="sortable">상품명<SortIndicator columnKey="productName" /></TableHead>
               <TableHead onClick={() => requestSort('mainAccountName')} className="sortable">본계정<SortIndicator columnKey="mainAccountName" /></TableHead>
               <TableHead onClick={() => requestSort('name')} className="sortable">타계정<SortIndicator columnKey="name" /></TableHead>
@@ -263,7 +262,7 @@ export default function AdminReviewManagementPage() {
               <TableHead><Input type="text" name="mainAccountName" value={filters.mainAccountName} onChange={handleFilterChange} /></TableHead>
               <TableHead><Input type="text" name="name" value={filters.name} onChange={handleFilterChange} /></TableHead>
               <TableHead><Input type="text" name="phoneNumber" value={filters.phoneNumber} onChange={handleFilterChange} /></TableHead>
-              <TableHead></TableHead><TableHead></TableHead><TableHead></TableHead><TableHead></TableHead>
+              <TableHead></TableHead><TableHead></TableHead><TableHead></TableHead>
               <TableHead><select name="reviewConfirm" value={filters.reviewConfirm} onChange={handleFilterChange}><option value="all">전체</option><option value="O">O</option><option value="X">X</option></select></TableHead>
               <TableHead></TableHead>
             </TableRow>
@@ -275,7 +274,6 @@ export default function AdminReviewManagementPage() {
                 {/* [수정] 헬퍼 함수 사용 */}
                 <TableCell>{formatTimestamp24h(r.createdAt)}</TableCell>
                 <TableCell>{getDisplayStatus(r)}</TableCell>
-                <TableCell>{r.serialNumber || '-'}</TableCell>
                 <TableCell className="product-name-cell">{r.productName || '-'}</TableCell>
                 <TableCell className="nowrap-cell">{r.mainAccountName || '-'}</TableCell>
                 <TableCell className="nowrap-cell">{r.name || '-'}</TableCell>


### PR DESCRIPTION
## Summary
- remove 고유번호 column from admin review table

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882e2329c5c8323a370634d2f55583b