### PR TITLE
Implement invoice column and grouping

### DIFF
--- a/frontend/src/pages/admin/SellerAdminProductManagement.jsx
+++ b/frontend/src/pages/admin/SellerAdminProductManagement.jsx
@@ -289,7 +289,7 @@ export default function AdminProductManagementPage() {
 
     if (!window.confirm(`선택한 ${ids.length}개의 캠페인을 예약 확정 처리하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`)) return;
     for (const id of ids) {
-      await handleConfirmDeposit(id, true);
+      await handleConfirmDeposit(id, true, true);
     }
   };
 
@@ -348,7 +348,7 @@ export default function AdminProductManagementPage() {
     }
   };
 
-  const handleConfirmDeposit = async (campaignId, isChecked) => {
+  const handleConfirmDeposit = async (campaignId, isChecked, skipPrompt = false) => {
     if (!isChecked) {
       try {
         await updateDoc(doc(db, 'campaigns', campaignId), { depositConfirmed: false });
@@ -359,7 +359,7 @@ export default function AdminProductManagementPage() {
       return;
     }
 
-    if (window.confirm("이 캠페인의 입금을 확인하고 예약을 최종 확정하시겠습니까?\n이 작업은 되돌릴 수 없습니다.")) {
+    if (skipPrompt || window.confirm("이 캠페인의 입금을 확인하고 예약을 최종 확정하시겠습니까?\n이 작업은 되돌릴 수 없습니다.")) {
         try {
             const campaignRef = doc(db, 'campaigns', campaignId);
             const snap = await getDoc(campaignRef);

--- a/frontend/src/pages/admin/SellerAdminProductManagement.jsx
+++ b/frontend/src/pages/admin/SellerAdminProductManagement.jsx
@@ -143,7 +143,8 @@ export default function AdminProductManagementPage() {
                 key,
                 items: [],
                 total: 0,
-                createdAt: c.createdAt
+                createdAt: c.createdAt,
+                isVatApplied: c.isVatApplied
             };
         }
         groups[key].items.push(c);
@@ -187,6 +188,7 @@ export default function AdminProductManagementPage() {
                     total: group.total,
                     id: group.key,
                     displayIndex: groupCounter,
+                    isVatApplied: group.isVatApplied
                 }
             });
         });
@@ -494,7 +496,7 @@ export default function AdminProductManagementPage() {
             <thead className="bg-gray-50">
               <tr>
                 <th className={thClass}><input type="checkbox" onChange={handleSelectAll} checked={groupedAndPaginatedCampaigns.length > 0 && groupedAndPaginatedCampaigns.every(c => selectedIds.includes(c.id))} /></th>
-                <th className={thClass}>상품군</th>
+                <th className={thClass}>발행여부</th>
                 <th className={thClass}>순번</th>
                 <th className={thClass + ' sortable'} onClick={() => requestSort('createdAt')}>
                   예약 등록 일자<SortIndicator columnKey="createdAt" />
@@ -532,7 +534,9 @@ export default function AdminProductManagementPage() {
                           <td className="px-3 py-4"><input type="checkbox" checked={selectedIds.includes(c.id)} onChange={() => handleSelectOne(c.id)} /></td>
                           
                           {c.renderInfo.shouldRender && (
-                            <td rowSpan={c.renderInfo.rowSpan} className="px-3 py-4 whitespace-nowrap text-sm text-center align-middle font-semibold">{`상품군 ${c.groupInfo.displayIndex}`}</td>
+                            <td rowSpan={c.renderInfo.rowSpan} className="px-3 py-4 whitespace-nowrap text-sm text-center align-middle font-semibold">
+                              {c.groupInfo.isVatApplied ? '세금계산서 발행' : '세금계산서 미발행'}
+                            </td>
                           )}
 
                           <td className="px-3 py-4 whitespace-nowrap text-sm">{(currentPage - 1) * itemsPerPage + index + 1}</td>

--- a/frontend/src/pages/admin/SellerAdminProductManagement.jsx
+++ b/frontend/src/pages/admin/SellerAdminProductManagement.jsx
@@ -142,12 +142,14 @@ export default function AdminProductManagementPage() {
             groups[key] = {
                 key,
                 items: [],
+                ids: [],
                 total: 0,
                 createdAt: c.createdAt,
                 isVatApplied: c.isVatApplied
             };
         }
         groups[key].items.push(c);
+        groups[key].ids.push(c.id);
         const { finalItemAmount } = computeAmounts(c);
         groups[key].total += finalItemAmount;
     });
@@ -188,7 +190,8 @@ export default function AdminProductManagementPage() {
                     total: group.total,
                     id: group.key,
                     displayIndex: groupCounter,
-                    isVatApplied: group.isVatApplied
+                    isVatApplied: group.isVatApplied,
+                    ids: group.ids
                 }
             });
         });
@@ -263,6 +266,14 @@ export default function AdminProductManagementPage() {
     } else {
       setSelectedIds([]);
     }
+  };
+
+  const handleSelectGroup = (ids, checked) => {
+    setSelectedIds(prev => {
+      let updated = prev.filter(id => !ids.includes(id));
+      if (checked) updated = [...updated, ...ids.filter(id => !updated.includes(id))];
+      return updated;
+    });
   };
 
   const handleSelectOne = (id) => {
@@ -495,6 +506,7 @@ export default function AdminProductManagementPage() {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
+                <th className={thClass}></th>
                 <th className={thClass}><input type="checkbox" onChange={handleSelectAll} checked={groupedAndPaginatedCampaigns.length > 0 && groupedAndPaginatedCampaigns.every(c => selectedIds.includes(c.id))} /></th>
                 <th className={thClass}>발행여부</th>
                 <th className={thClass}>순번</th>
@@ -525,14 +537,20 @@ export default function AdminProductManagementPage() {
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
                 {groupedAndPaginatedCampaigns.length === 0 ? (
-                    <tr><td colSpan="21" className="text-center py-10">데이터가 없습니다.</td></tr>
+                    <tr><td colSpan="22" className="text-center py-10">데이터가 없습니다.</td></tr>
                 ) : (
                     groupedAndPaginatedCampaigns.map((c, index) => {
                       const { finalItemAmount } = computeAmounts(c);
                       return (
                         <tr key={c.id} className="hover:bg-gray-50">
+                          {c.renderInfo.shouldRender && (
+                            <td rowSpan={c.renderInfo.rowSpan} className="px-3 py-4 whitespace-nowrap text-sm text-center align-middle">
+                              <input type="checkbox" onChange={(e)=>handleSelectGroup(c.groupInfo.ids, e.target.checked)}
+                                     checked={c.groupInfo.ids.every(id => selectedIds.includes(id))} />
+                            </td>
+                          )}
                           <td className="px-3 py-4"><input type="checkbox" checked={selectedIds.includes(c.id)} onChange={() => handleSelectOne(c.id)} /></td>
-                          
+
                           {c.renderInfo.shouldRender && (
                             <td rowSpan={c.renderInfo.rowSpan} className="px-3 py-4 whitespace-nowrap text-sm text-center align-middle font-semibold">
                               {c.groupInfo.isVatApplied ? '세금계산서 발행' : '세금계산서 미발행'}


### PR DESCRIPTION
## Summary
- rename column to show 발행여부 in seller products admin
- display 세금계산서 발행 status per reservation group
- group products on admin products page with group checkboxes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68830e06971c832381ea7944bc57e310