### PR TITLE
Add collapsible mobile menu for admin

### DIFF
--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -1,6 +1,7 @@
 // src/pages/AdminLayout.jsx (트래픽 관리 메뉴 추가)
 
 import { Outlet, NavLink, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { auth, signOut } from '../firebaseConfig';
 import './AdminLayout.css';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -8,6 +9,28 @@ import { cn } from '@/lib/utils';
 
 export default function AdminLayout() {
   const navigate = useNavigate();
+  const [isMobile, setIsMobile] = useState(false);
+  const [reviewerOpen, setReviewerOpen] = useState(true);
+  const [sellerOpen, setSellerOpen] = useState(true);
+
+  useEffect(() => {
+    const checkMobile = () => window.innerWidth <= 768;
+    const handleResize = () => setIsMobile(checkMobile());
+
+    setIsMobile(checkMobile());
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) {
+      setReviewerOpen(false);
+      setSellerOpen(false);
+    } else {
+      setReviewerOpen(true);
+      setSellerOpen(true);
+    }
+  }, [isMobile]);
 
   const handleLogout = async () => {
     try {
@@ -25,23 +48,161 @@ export default function AdminLayout() {
         <Button variant="outline" size="sm" className="w-full mb-4" onClick={handleLogout}>로그아웃</Button>
         <nav>
           {/* --- 기존 리뷰어 관리 메뉴 --- */}
-          <h3 className="menu-section-title">리뷰어 관리</h3>
-          <NavLink to="/admin/members" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>회원 관리</NavLink>
-          <NavLink to="/admin/products" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>상품 등록 및 관리</NavLink>
-          <NavLink to="/admin/reviews" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>리뷰어 구매 관리</NavLink>
-          <NavLink to="/admin/settlement" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>정산 관리</NavLink>
-          <NavLink to="/admin/settlement-complete" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>정산 완료 내역</NavLink>
+          <h3
+            className="menu-section-title" 
+            onClick={() => isMobile && setReviewerOpen(!reviewerOpen)}
+          >
+            리뷰어 관리
+          </h3>
+          {(!isMobile || reviewerOpen) && (
+            <>
+              <NavLink
+                to="/admin/members"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                회원 관리
+              </NavLink>
+              <NavLink
+                to="/admin/products"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                상품 등록 및 관리
+              </NavLink>
+              <NavLink
+                to="/admin/reviews"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                리뷰어 구매 관리
+              </NavLink>
+              <NavLink
+                to="/admin/settlement"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                정산 관리
+              </NavLink>
+              <NavLink
+                to="/admin/settlement-complete"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                정산 완료 내역
+              </NavLink>
+            </>
+          )}
 
           {/* --- 신규 판매자/캠페인 관리 메뉴 --- */}
-          <h3 className="menu-section-title">판매자/캠페인 관리</h3>
-          <NavLink to="/admin/seller-dashboard" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>대시보드</NavLink>
-          <NavLink to="/admin/seller-products" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>캠페인 관리</NavLink>
-          {/* [추가] 트래픽 관리 메뉴 */}
-          <NavLink to="/admin/seller-traffic-management" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>트래픽 관리</NavLink>
-          <NavLink to="/admin/seller-list" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>판매자 목록</NavLink>
-          <NavLink to="/admin/seller-schedule" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>예약 시트 관리</NavLink>
-          <NavLink to="/admin/seller-progress" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>진행현황</NavLink>
-          <NavLink to="/admin/seller-traffic" className={({ isActive }) => cn(buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }), 'justify-start w-full')}>트래픽 설정</NavLink>
+          <h3
+            className="menu-section-title"
+            onClick={() => isMobile && setSellerOpen(!sellerOpen)}
+          >
+            판매자/캠페인 관리
+          </h3>
+          {(!isMobile || sellerOpen) && (
+            <>
+              <NavLink
+                to="/admin/seller-dashboard"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                대시보드
+              </NavLink>
+              <NavLink
+                to="/admin/seller-products"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                캠페인 관리
+              </NavLink>
+              {/* [추가] 트래픽 관리 메뉴 */}
+              <NavLink
+                to="/admin/seller-traffic-management"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                트래픽 관리
+              </NavLink>
+              <NavLink
+                to="/admin/seller-list"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                판매자 목록
+              </NavLink>
+              <NavLink
+                to="/admin/seller-schedule"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                예약 시트 관리
+              </NavLink>
+              <NavLink
+                to="/admin/seller-progress"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                진행현황
+              </NavLink>
+              <NavLink
+                to="/admin/seller-traffic"
+                className={({ isActive }) =>
+                  cn(
+                    buttonVariants({ variant: isActive ? 'secondary' : 'ghost', size: 'sm' }),
+                    'justify-start w-full'
+                  )
+                }
+              >
+                트래픽 설정
+              </NavLink>
+            </>
+          )}
         </nav>
       </aside>
       <main>


### PR DESCRIPTION
## Summary
- collapse admin layout menu groups on mobile

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835bfea9f48323a2927ab05c439287