### PR TITLE
Adjust admin fonts on mobile

### DIFF
--- a/frontend/src/pages/AdminLayout.css
+++ b/frontend/src/pages/AdminLayout.css
@@ -289,11 +289,11 @@ main h2 {
 @media (max-width: 768px) {
   .admin-layout {
     flex-direction: column;
-    font-size: 70%;
+    font-size: 80%;
   }
 
   .admin-layout * {
-    font-size: 70% !important;
+    font-size: 80% !important;
   }
 
   aside {

--- a/frontend/src/pages/AdminLayout.css
+++ b/frontend/src/pages/AdminLayout.css
@@ -289,6 +289,11 @@ main h2 {
 @media (max-width: 768px) {
   .admin-layout {
     flex-direction: column;
+    font-size: 70%;
+  }
+
+  .admin-layout * {
+    font-size: 70% !important;
   }
 
   aside {


### PR DESCRIPTION
## Summary
- shrink admin layout fonts to 70% for mobile view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884661523bc832397753c6c1e7dd7c7